### PR TITLE
feat: Add battery reading wrapper

### DIFF
--- a/buttplug4j.connectors.jetty.websocket.client/src/test/java/io/github/blackspherefollower/buttplug4j/connectors/jetty/websocket/client/ButtplugClientWSJettyClientTest.java
+++ b/buttplug4j.connectors.jetty.websocket.client/src/test/java/io/github/blackspherefollower/buttplug4j/connectors/jetty/websocket/client/ButtplugClientWSJettyClientTest.java
@@ -1,11 +1,14 @@
 package io.github.blackspherefollower.buttplug4j.connectors.jetty.websocket.client;
 
 import io.github.blackspherefollower.buttplug4j.client.ButtplugClientDevice;
+import io.github.blackspherefollower.buttplug4j.client.ButtplugDeviceException;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ButtplugClientWSJettyClientTest {
@@ -47,6 +50,31 @@ public class ButtplugClientWSJettyClientTest {
 
         Thread.sleep(1000);
         assertTrue(client.stopAllDevices());
+
+        client.disconnect();
+    }
+
+    @Disabled
+    @Test
+    public void TestBattery() throws Exception {
+        ButtplugClientWSClient client = new ButtplugClientWSClient("Java Test");
+        client.connect(new URI("ws://localhost:12345/buttplug"));
+        client.startScanning();
+
+        Thread.sleep(2000);
+        client.requestDeviceList();
+        for (ButtplugClientDevice dev : client.getDevices()) {
+            if (dev.hasBatterySensor()) {
+                long battery = dev.readBatteryLevel();
+                System.out.println("Battery is " + battery);
+                assertTrue(battery >= 0);
+                assertTrue(battery <= 100);
+            } else {
+                assertThrows(ButtplugDeviceException.class, () -> {
+                    long battery = dev.readBatteryLevel();
+                });
+            }
+        }
 
         client.disconnect();
     }

--- a/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDevice.java
+++ b/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDevice.java
@@ -1,5 +1,6 @@
 package io.github.blackspherefollower.buttplug4j.client;
 
+import io.github.blackspherefollower.buttplug4j.protocol.ButtplugConsts;
 import io.github.blackspherefollower.buttplug4j.protocol.ButtplugMessage;
 import io.github.blackspherefollower.buttplug4j.protocol.messages.*;
 import io.github.blackspherefollower.buttplug4j.protocol.messages.Parts.*;
@@ -392,7 +393,7 @@ public class ButtplugClientDevice {
      * is thrown.
      * </p>
      * 
-     * @param index The index of the sensor feature to read. This value specifies which sensor data 
+     * @param sensorIndex The index of the sensor feature to read. This value specifies which sensor data 
      *              to retrieve from the device.
      * @param sensorType The type of sensor to read (e.g., "Battery"). This value indicates the specific 
      *                   type of sensor data requested.
@@ -404,7 +405,7 @@ public class ButtplugClientDevice {
      * @throws ButtplugDeviceException if the device does not support "SensorReadCmd" or if 
      *                                 the sensor read command could not be created or sent.
      */
-    public final Future<ButtplugMessage> sendSensorReadCmd(final int index, final String sensorType)
+    public final Future<ButtplugMessage> sendSensorReadCmd(final int sensorIndex, final String sensorType)
             throws ButtplugDeviceException {
 
         MessageAttributes attrs = getDeviceMessages().get("SensorReadCmd");
@@ -412,8 +413,9 @@ public class ButtplugClientDevice {
             throw new ButtplugDeviceException("Device doesn't support SensorReadCmd!");
         }
 
-        final SensorReadCmd cmd = new SensorReadCmd(index, index);
+        final SensorReadCmd cmd = new SensorReadCmd(this.deviceIndex, ButtplugConsts.DEFAULT_MSG_ID);
         cmd.setSensorType(sensorType);
+        cmd.setSensorIndex(sensorIndex);
 
         return client.sendDeviceMessage(this, cmd);
     }


### PR DESCRIPTION
This change introduces hasBatterySensor, readBatteryLevel, and sendSensorReadCmd to handle battery level reading from devices. These functions allow checking for a battery sensor, reading the battery level, and sending a sensor read command to the device.