### PR TITLE
Thread jetty client disconnect() to avoid WS deadlock

### DIFF
--- a/buttplug4j.connectors.jetty.websocket.client/src/main/java/io/github/blackspherefollower/buttplug4j/connectors/jetty/websocket/client/ButtplugClientWSClient.java
+++ b/buttplug4j.connectors.jetty.websocket.client/src/main/java/io/github/blackspherefollower/buttplug4j/connectors/jetty/websocket/client/ButtplugClientWSClient.java
@@ -117,7 +117,7 @@ public final class ButtplugClientWSClient extends ButtplugClient {
         } else {
             cause.printStackTrace();
         }
-        disconnect();
+        new Thread(() -> disconnect()).start();
     }
 
     @Override


### PR DESCRIPTION
When an error occurs in a Jetty WebSocket client, it calls the `@OnWebSocketError` callback from one of its own threads. This causes the client to hang during shutdown because [part of the shutdown process waits for all of its own threads to exit gracefully](https://github.com/jetty/jetty.project/issues/5155#issuecomment-674114291). Running the client's `disconnect()` function from a new thread allows the client to exit without hanging on error.